### PR TITLE
Bugfix for eval_in_model

### DIFF
--- a/src/pymc_ext/utils.py
+++ b/src/pymc_ext/utils.py
@@ -37,7 +37,7 @@ def eval_in_model(outs, point=None, model=None, seed=None, **kwargs):
     """
     if point is None:
         model = pm.modelcontext(model)
-        point = model.initial_point(seed=seed)
+        point = model.initial_point(random_seed=seed)
     return Evaluator(outs, **kwargs)(point)
 
 


### PR DESCRIPTION
For reasons I don't understand, https://github.com/pymc-devs/pymc/pull/6291 changed the keyword to the `initial_point` method from `seed` to `random_seed`. This PR makes `pymc-ext` use the updated argument.