### PR TITLE
Support for PyMC >= 5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         exclude: docs/tutorials
 
   - repo: https://github.com/PyCQA/isort
-    rev: "5.10.1"
+    rev: "5.11.5"
     hooks:
       - id: isort
         args: []

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]
-INSTALL_REQUIRES = ["pymc"]
+INSTALL_REQUIRES = ["pymc >= 5.0.0"]
 EXTRA_REQUIRE = {
     "test": ["pytest"],
     "notebooks": [

--- a/src/pymc_ext/distributions.py
+++ b/src/pymc_ext/distributions.py
@@ -2,9 +2,9 @@ __all__ = ["angle", "unit_disk"]
 
 import warnings
 
-import aesara.tensor as at
 import numpy as np
 import pymc as pm
+import pytensor.tensor as pt
 
 
 def angle(name, *, regularization=10.0, **kwargs):
@@ -21,15 +21,15 @@ def angle(name, *, regularization=10.0, **kwargs):
     value of ``10.0`` is a good starting point.
     """
     shape = kwargs.get("shape", ())
-    initval = kwargs.pop("initval", at.broadcast_to(0.0, shape))
+    initval = kwargs.pop("initval", pt.broadcast_to(0.0, shape))
     x1 = pm.Normal(f"__{name}_angle1", initval=np.sin(initval), **kwargs)
     x2 = pm.Normal(f"__{name}_angle2", initval=np.cos(initval), **kwargs)
     if regularization is not None:
         pm.Potential(
             f"__{name}_regularization",
-            regularization * at.log(x1**2 + x2**2),
+            regularization * pt.log(x1**2 + x2**2),
         )
-    return pm.Deterministic(name, at.arctan2(x1, x2))
+    return pm.Deterministic(name, pt.arctan2(x1, x2))
 
 
 def unit_disk(name_x, name_y, **kwargs):
@@ -57,6 +57,6 @@ def unit_disk(name_x, name_y, **kwargs):
         initval=initval[1] * np.sqrt(1 - initval[0] ** 2),
         **kwargs,
     )
-    norm = at.sqrt(1 - x1**2)
-    pm.Potential(f"__{name_y}_jacobian", at.log(norm))
+    norm = pt.sqrt(1 - x1**2)
+    pm.Potential(f"__{name_y}_jacobian", pt.log(norm))
     return x1, pm.Deterministic(name_y, x2 * norm)

--- a/src/pymc_ext/optim.py
+++ b/src/pymc_ext/optim.py
@@ -11,9 +11,15 @@ def optimize(start=None, vars=None, **kwargs):
         if not isinstance(vars, (list, tuple)):
             vars = [vars]
 
+        # In PyMC >= 5, model context is required to replace rvs with values
+        # https://github.com/pymc-devs/pymc/pull/6281
+        # https://www.pymc.io/projects/docs/en/stable/learn/core_notebooks/pymc_pytensor.html#pymc
+        model = kwargs.get("model")
+        model = pm.modelcontext(model)
+
         # find_MAP only supports passing in members of free_RVs, so let's deal
         # with that here...
-        vars = pm.pytensorf.rvs_to_value_vars(vars)
+        vars = model.replace_rvs_by_values(vars)
         vars = [
             v
             for v in graph_inputs(vars)

--- a/src/pymc_ext/optim.py
+++ b/src/pymc_ext/optim.py
@@ -1,8 +1,8 @@
 __all__ = ["optimize"]
 
 import pymc as pm
-from aesara.graph.basic import graph_inputs
-from aesara.tensor.var import TensorConstant, TensorVariable
+from pytensor.graph.basic import graph_inputs
+from pytensor.tensor.variable import TensorConstant, TensorVariable
 
 
 def optimize(start=None, vars=None, **kwargs):
@@ -13,7 +13,7 @@ def optimize(start=None, vars=None, **kwargs):
 
         # find_MAP only supports passing in members of free_RVs, so let's deal
         # with that here...
-        vars = pm.aesaraf.rvs_to_value_vars(vars)
+        vars = pm.pytensorf.rvs_to_value_vars(vars)
         vars = [
             v
             for v in graph_inputs(vars)

--- a/src/pymc_ext/utils.py
+++ b/src/pymc_ext/utils.py
@@ -5,13 +5,14 @@ import pymc as pm
 
 
 class Evaluator:
+    # TODO: Add some documentation
     def __init__(self, outs, **kwargs):
         if isinstance(outs, (tuple, list)):
-            self.out_values = pm.aesaraf.rvs_to_value_vars(outs)
+            self.out_values = pm.pytensorf.rvs_to_value_vars(outs)
         else:
-            self.out_values = pm.aesaraf.rvs_to_value_vars([outs])[0]
+            self.out_values = pm.pytensorf.rvs_to_value_vars([outs])[0]
         self.in_values = pm.inputvars(self.out_values)
-        self.func = pm.aesaraf.compile_pymc(
+        self.func = pm.pytensorf.compile_pymc(
             self.in_values, self.out_values, **kwargs
         )
 
@@ -21,7 +22,7 @@ class Evaluator:
 
 
 def eval_in_model(outs, point=None, model=None, seed=None, **kwargs):
-    """Evaluate a Theano tensor or PyMC3 variable in a PyMC3 model
+    """Evaluate a PyTensor tensor or PyMC variable in a PyMC model
 
     This method builds a Theano function for evaluating a node in the graph
     given the required parameters. This will also cache the compiled Theano

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # ref: https://github.com/pymc-devs/pymc3/blob/master/pymc3/tests/conftest.py
 
-import aesara
+import pytensor
 import pytest
 
 
 @pytest.fixture(scope="package", autouse=True)
 def theano_config():
     flags = dict(compute_test_value="off")
-    config = aesara.configparser.change_flags(**flags)
+    config = pytensor.config.change_flags(**flags)
     with config:
         yield

--- a/tests/optim_test.py
+++ b/tests/optim_test.py
@@ -1,6 +1,6 @@
-import aesara.tensor as at
 import numpy as np
 import pymc as pm
+import pytensor.tensor as pt
 import pytest
 
 from pymc_ext.optim import optimize

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -12,3 +12,30 @@ def test_eval_in_model(seed=123409):
         x = pm.Normal("x", shape=x_val.shape, initval=x_val)
         assert np.allclose(eval_in_model(x), x_val)
         assert np.allclose(eval_in_model(x, {"x": x_val2}), x_val2)
+
+
+def test_eval_in_model_uniform(seed=123409):
+    # test_eval_in_model has unconstrained (-inf, inf) variables only
+    # Uniform has implicit transform in PyMC so check that this works too with
+    # eval_in_model
+    rng = np.random.default_rng(seed)
+    x_val = rng.uniform(size=(5, 3))
+    with pm.Model():
+        x = pm.Uniform("x", shape=x_val.shape, initval=x_val)
+
+        assert np.allclose(eval_in_model(x), x_val)
+
+
+def test_eval_in_model_list(seed=123409):
+    # The utils.Evaluator class handles list of variables differently
+    # from single variables, so we test this here.
+    rng = np.random.default_rng(seed)
+    x_val = rng.uniform(size=(5, 3))
+    y_val = rng.standard_normal()
+
+    with pm.Model():
+        x = pm.Uniform("x", shape=x_val.shape, initval=x_val)
+        y = pm.Normal("y", initval=y_val)
+        x_eval, y_eval = eval_in_model([x, y])
+        assert np.allclose(x_eval, x_val)
+        assert np.allclose(y_eval, y_val)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -9,6 +9,6 @@ def test_eval_in_model(seed=123409):
     x_val = np.random.randn(5, 3)
     x_val2 = np.random.randn(5, 3)
     with pm.Model():
-        x = pm.Normal("x", shape=x_val.shape, testval=x_val)
+        x = pm.Normal("x", shape=x_val.shape, initval=x_val)
         assert np.allclose(eval_in_model(x), x_val)
         assert np.allclose(eval_in_model(x, {"x": x_val2}), x_val2)


### PR DESCRIPTION
Hi!

After playing with PyMC >= 5 for exoplanet-core (exoplanet-dev/exoplanet-core#89), I thought I'd give this one a try.

Most changes boil down to replacing `aesara` with `pytensor`. I also updated some `testval` arguments to `initval`.

One somewhat important change is that `pm.pytensorf.rvs_to_value_vars()` was deprecated with a warning, so I replaced it with `pymc.Model().replace_rvs_by_values()`, which is equivalent but requires the model context. The `pm.pytensorf.replace_rvs_by_values()` requires extra keyword arguments which are passed automatically by the model method.

Also, the `isort` pre-commit hook failed so I updated the version (ref: PyCQA/isort#2108)