### PR TITLE
Add back `estimate_inverse_gamma_parameters()` in utils

### DIFF
--- a/src/pymc_ext/utils.py
+++ b/src/pymc_ext/utils.py
@@ -1,7 +1,14 @@
-__all__ = ["Evaluator", "eval_in_model", "sample_inference_data"]
+__all__ = [
+    "Evaluator",
+    "eval_in_model",
+    "sample_inference_data",
+    "estimate_inverse_gamma_parameters",
+]
 
 import numpy as np
 import pymc as pm
+from scipy.optimize import root
+from scipy.special import gammaincc
 
 
 class Evaluator:
@@ -75,3 +82,47 @@ def sample(**kwargs):
     kwargs["target_accept"] = kwargs.get("target_accept", 0.9)
     kwargs["init"] = kwargs.get("init", "adapt_full")
     return pm.sample(**kwargs)
+
+
+def estimate_inverse_gamma_parameters(
+    lower, upper, target=0.01, initial=None, **kwargs
+):
+    r"""Estimate an inverse Gamma with desired tail probabilities
+    This method numerically solves for the parameters of an inverse Gamma
+    distribution where the tails have a given probability. In other words
+    :math:`P(x < \mathrm{lower}) = \mathrm{target}` and similarly for the
+    upper bound. More information can be found in `part 4 of this blog post
+    <https://betanalpha.github.io/assets/case_studies/gp_part3/part3.html>`_.
+    Args:
+        lower (float): The location of the lower tail
+        upper (float): The location of the upper tail
+        target (float, optional): The desired tail probability
+        initial (ndarray, optional): An initial guess for the parameters
+            ``alpha`` and ``beta``
+    Raises:
+        RuntimeError: If the solver does not converge.
+    Returns:
+        dict: A dictionary with the keys ``alpha`` and ``beta`` for the
+        parameters of the distribution.
+    """
+    lower, upper = np.sort([lower, upper])
+    if initial is None:
+        initial = np.array([2.0, 0.5 * (lower + upper)])
+    if np.shape(initial) != (2,) or np.any(np.asarray(initial) <= 0.0):
+        raise ValueError("invalid initial guess")
+
+    def obj(x):
+        a, b = np.exp(x)
+        return np.array(
+            [
+                gammaincc(a, b / lower) - target,
+                1 - gammaincc(a, b / upper) - target,
+            ]
+        )
+
+    result = root(obj, np.log(initial), method="hybr", **kwargs)
+    if not result.success:
+        raise RuntimeError(
+            "failed to find parameter estimates: \n{0}".format(result.message)
+        )
+    return dict(zip(("alpha", "beta"), np.exp(result.x)))


### PR DESCRIPTION
Hi!

While updating the [case studies](https://github.com/exoplanet-dev/case-studies) repo to PyMC v5, I noticed that `pymc_ext.utils.estimate_inverse_gamma_parameters` was removed during the update to PyMC v4.
I added it back to be able to run the case studies.
If it was moved somewhere else or if it was removed intentionally, let me know and I will update the case studies accordingly.
Otherwise, this PR simply adds back the old version.

Thanks!